### PR TITLE
use commonConfig.applicationName for object naming

### DIFF
--- a/deploy/examples/common_config.yaml
+++ b/deploy/examples/common_config.yaml
@@ -8,5 +8,5 @@ spec:
     # By default is the cr.Name
     applicationName: other
     adminPassword: example
-    imageTag: "1.0-stage"
-    mavenRepo: https://maven.example.com
+    imageTag: 1.0-stage
+    mavenRepo: INTERNAL

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -69,7 +69,9 @@ func getEnvTemplate(cr *v1.KieApp) (v1.EnvTemplate, error) {
 
 	// set default values for go template where not provided
 	config := &cr.Spec.CommonConfig
-	config.ApplicationName = cr.Name
+	if config.ApplicationName == "" {
+		config.ApplicationName = cr.Name
+	}
 	setAppConstants(&cr.Spec)
 	isTrialEnv := strings.HasSuffix(string(cr.Spec.Environment), constants.TrialEnvSuffix)
 	setPasswords(config, isTrialEnv)
@@ -115,9 +117,9 @@ func getServersConfig(cr *v1.KieApp, commonConfig *v1.CommonConfig) ([]v1.Server
 		serverSet := &cr.Spec.Objects.Servers[index]
 		if serverSet.Name == "" {
 			if len(cr.Spec.Objects.Servers) == 1 {
-				serverSet.Name = fmt.Sprintf("%v-kieserver", cr.Name)
+				serverSet.Name = fmt.Sprintf("%v-kieserver", cr.Spec.CommonConfig.ApplicationName)
 			} else {
-				serverSet.Name = fmt.Sprintf("%v-kieserver%v", cr.Name, index)
+				serverSet.Name = fmt.Sprintf("%v-kieserver%v", cr.Spec.CommonConfig.ApplicationName, index)
 			}
 		} else if usedNames[serverSet.Name] {
 			return []v1.ServerTemplate{}, fmt.Errorf("duplicate kieserver name %s", serverSet.Name)

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -3,11 +3,12 @@ package defaults
 import (
 	"context"
 	"fmt"
-	"github.com/ghodss/yaml"
-	"github.com/gobuffalo/packr"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/gobuffalo/packr"
 
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -100,7 +101,7 @@ func TestMultipleServerDeployment(t *testing.T) {
 
 	env, err := GetEnvironment(cr, test.MockService())
 	assert.Equal(t, deployments, len(env.Servers))
-	assert.Equal(t, fmt.Sprintf("%s-kieserver-%d", cr.Name, deployments), env.Servers[deployments-1].DeploymentConfigs[0].Name)
+	assert.Equal(t, fmt.Sprintf("%s-kieserver-%d", cr.Spec.CommonConfig.ApplicationName, deployments), env.Servers[deployments-1].DeploymentConfigs[0].Name)
 	assert.Nil(t, err)
 }
 
@@ -132,7 +133,7 @@ func TestRHPAMTrialEnvironment(t *testing.T) {
 	assert.NotNil(t, pingService, "Ping service not found")
 	assert.Len(t, pingService.Spec.Ports, 1, "The ping service should have only one port")
 	assert.Equal(t, int32(8888), pingService.Spec.Ports[0].Port, "The ping service should listen on port 8888")
-	assert.Equal(t, fmt.Sprintf("%s-kieserver-%d", cr.Name, len(env.Servers)), env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Name, "the container name should have incremented")
+	assert.Equal(t, fmt.Sprintf("%s-kieserver-%d", cr.Spec.CommonConfig.ApplicationName, len(env.Servers)), env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Name, "the container name should have incremented")
 	assert.Equal(t, "test-rhpamcentr", env.Console.DeploymentConfigs[0].ObjectMeta.Name)
 	assert.Equal(t, fmt.Sprintf("rhpam%s-businesscentral-openshift", cr.Spec.CommonConfig.Version), env.Console.DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, "curl --fail --silent -u \"${KIE_ADMIN_USER}\":\"${KIE_ADMIN_PWD}\" http://localhost:8080/kie-wb.jsp", env.Console.DeploymentConfigs[0].Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command[2])
@@ -167,7 +168,7 @@ func TestRHDMTrialEnvironment(t *testing.T) {
 	assert.NotNil(t, pingService, "Ping service not found")
 	assert.Len(t, pingService.Spec.Ports, 1, "The ping service should have only one port")
 	assert.Equal(t, int32(8888), pingService.Spec.Ports[0].Port, "The ping service should listen on port 8888")
-	assert.Equal(t, fmt.Sprintf("%s-kieserver-%d", cr.Name, len(env.Servers)), env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Name, "the container name should have incremented")
+	assert.Equal(t, fmt.Sprintf("%s-kieserver-%d", cr.Spec.CommonConfig.ApplicationName, len(env.Servers)), env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Name, "the container name should have incremented")
 	assert.Equal(t, "test-rhdmcentr", env.Console.DeploymentConfigs[0].ObjectMeta.Name)
 	assert.Equal(t, fmt.Sprintf("rhdm%s-decisioncentral-openshift", cr.Spec.CommonConfig.Version), env.Console.DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, "curl --fail --silent -u \"${KIE_ADMIN_USER}\":\"${KIE_ADMIN_PWD}\" http://localhost:8080/kie-wb.jsp", env.Console.DeploymentConfigs[0].Spec.Template.Spec.Containers[0].ReadinessProbe.Exec.Command[2])
@@ -371,7 +372,7 @@ func TestAuthoringEnvironment(t *testing.T) {
 	}
 	env, err := GetEnvironment(cr, test.MockService())
 	assert.Nil(t, err, "Error getting authoring environment")
-	assert.Equal(t, fmt.Sprintf("%s-kieserver", cr.Name), env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Name, "the container name should have incremented")
+	assert.Equal(t, fmt.Sprintf("%s-kieserver", cr.Spec.CommonConfig.ApplicationName), env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Name, "the container name should have incremented")
 	assert.NotEqual(t, v1.Environment{}, env, "Environment should not be empty")
 }
 
@@ -386,7 +387,7 @@ func TestAuthoringHAEnvironment(t *testing.T) {
 	}
 	env, err := GetEnvironment(cr, test.MockService())
 	assert.Nil(t, err, "Error getting authoring-ha environment")
-	assert.Equal(t, fmt.Sprintf("%s-kieserver", cr.Name), env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Name, "the container name should have incremented")
+	assert.Equal(t, fmt.Sprintf("%s-kieserver", cr.Spec.CommonConfig.ApplicationName), env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Name, "the container name should have incremented")
 	assert.NotEqual(t, v1.Environment{}, env, "Environment should not be empty")
 }
 

--- a/pkg/controller/kieapp/kieapp_controller.go
+++ b/pkg/controller/kieapp/kieapp_controller.go
@@ -296,7 +296,7 @@ func (reconciler *Reconciler) newEnv(cr *v1.KieApp) (v1.Environment, reconcile.R
 			}
 		}
 		if consoleCN == "" {
-			consoleCN = cr.Name
+			consoleCN = cr.Spec.CommonConfig.ApplicationName
 			cr.Status.ConsoleHost = fmt.Sprintf("http://%s", consoleCN)
 		}
 
@@ -304,10 +304,10 @@ func (reconciler *Reconciler) newEnv(cr *v1.KieApp) (v1.Environment, reconcile.R
 		env.Console.Secrets = append(env.Console.Secrets, corev1.Secret{
 			Type: corev1.SecretTypeOpaque,
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("%s-businesscentral-app-secret", cr.Name),
+				Name: fmt.Sprintf("%s-businesscentral-app-secret", cr.Spec.CommonConfig.ApplicationName),
 				Labels: map[string]string{
-					"app":         cr.Name,
-					"application": cr.Name,
+					"app":         cr.Spec.CommonConfig.ApplicationName,
+					"application": cr.Spec.CommonConfig.ApplicationName,
 				},
 			},
 			Data: map[string][]byte{
@@ -330,7 +330,7 @@ func (reconciler *Reconciler) newEnv(cr *v1.KieApp) (v1.Environment, reconcile.R
 			}
 		}
 		if serverCN == "" {
-			serverCN = cr.Name
+			serverCN = cr.Spec.CommonConfig.ApplicationName
 		}
 		defaults.ConfigureHostname(&server, cr, serverCN)
 		serverSet, relativeIndex := defaults.GetServerSet(cr, i)
@@ -341,8 +341,8 @@ func (reconciler *Reconciler) newEnv(cr *v1.KieApp) (v1.Environment, reconcile.R
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s%s-app-secret", kieName, kieIndex),
 				Labels: map[string]string{
-					"app":         cr.Name,
-					"application": cr.Name,
+					"app":         cr.Spec.CommonConfig.ApplicationName,
+					"application": cr.Spec.CommonConfig.ApplicationName,
 				},
 			},
 			Data: map[string][]byte{
@@ -364,17 +364,17 @@ func (reconciler *Reconciler) newEnv(cr *v1.KieApp) (v1.Environment, reconcile.R
 			}
 		}
 		if smartCN == "" {
-			smartCN = cr.Name
+			smartCN = cr.Spec.CommonConfig.ApplicationName
 		}
 
 		defaults.ConfigureHostname(&env.Smartrouter, cr, smartCN)
 		env.Smartrouter.Secrets = append(env.Smartrouter.Secrets, corev1.Secret{
 			Type: corev1.SecretTypeOpaque,
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("%s-smartrouter-app-secret", cr.Name),
+				Name: fmt.Sprintf("%s-smartrouter-app-secret", cr.Spec.CommonConfig.ApplicationName),
 				Labels: map[string]string{
-					"app":         cr.Name,
-					"application": cr.Name,
+					"app":         cr.Spec.CommonConfig.ApplicationName,
+					"application": cr.Spec.CommonConfig.ApplicationName,
 				},
 			},
 			Data: map[string][]byte{

--- a/pkg/controller/kieapp/kieapp_controller_test.go
+++ b/pkg/controller/kieapp/kieapp_controller_test.go
@@ -71,6 +71,9 @@ func TestTrialConsoleEnv(t *testing.T) {
 		},
 		Spec: v1.KieAppSpec{
 			Environment: "rhdm-trial",
+			CommonConfig: v1.CommonConfig{
+				ApplicationName: "trial",
+			},
 			Objects: v1.KieAppObjects{
 				Console: v1.SecuredKieAppObject{
 					KieAppObject: v1.KieAppObject{
@@ -90,7 +93,7 @@ func TestTrialConsoleEnv(t *testing.T) {
 	}
 	env = consolidateObjects(env, cr)
 
-	assert.Equal(t, fmt.Sprintf("%s-rhdmcentr", cr.Name), env.Console.DeploymentConfigs[0].Name)
+	assert.Equal(t, fmt.Sprintf("%s-rhdmcentr", cr.Spec.CommonConfig.ApplicationName), env.Console.DeploymentConfigs[0].Name)
 	re := regexp.MustCompile("[0-9]+")
 	assert.Equal(t, fmt.Sprintf("rhdm%s-decisioncentral-openshift:%s", strings.Join(re.FindAllString(constants.ProductVersion, -1), ""), constants.ImageStreamTag), env.Console.DeploymentConfigs[0].Spec.Triggers[0].ImageChangeParams.From.Name)
 	assert.Contains(t, env.Console.DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env, envReplace, "Environment overriding not functional")
@@ -170,7 +173,7 @@ func TestTrialServerEnv(t *testing.T) {
 	env = consolidateObjects(env, cr)
 
 	assert.Equal(t, deployments, len(env.Servers))
-	assert.Equal(t, fmt.Sprintf("%s-kieserver-%d", cr.Name, deployments), env.Servers[deployments-1].DeploymentConfigs[0].Name)
+	assert.Equal(t, fmt.Sprintf("%s-kieserver-%d", cr.Spec.CommonConfig.ApplicationName, deployments), env.Servers[deployments-1].DeploymentConfigs[0].Name)
 	pattern := regexp.MustCompile("[0-9]+")
 	expectedISTagName := fmt.Sprintf("rhpam%s-kieserver-openshift:%s", strings.Join(pattern.FindAllString(constants.ProductVersion, -1), ""), constants.ImageStreamTag)
 	assert.Equal(t, expectedISTagName, env.Servers[0].DeploymentConfigs[0].Spec.Triggers[0].ImageChangeParams.From.Name)
@@ -344,7 +347,7 @@ func TestConsoleHost(t *testing.T) {
 	reconciler := &Reconciler{mockService}
 	_, _, err = reconciler.newEnv(cr)
 	assert.Nil(t, err, "Error creating a new environment")
-	assert.Equal(t, fmt.Sprintf("http://%s", cr.Name), cr.Status.ConsoleHost, "spec.commonConfig.consoleHost should be URL from the resulting workbench route host")
+	assert.Equal(t, fmt.Sprintf("http://%s", cr.Spec.CommonConfig.ApplicationName), cr.Status.ConsoleHost, "spec.commonConfig.consoleHost should be URL from the resulting workbench route host")
 }
 
 func TestMergeTrialAndCommonConfig(t *testing.T) {


### PR DESCRIPTION
also resolves https://issues.jboss.org/browse/KIECLOUD-139... issues w/ common-config example.

Signed-off-by: tchughesiv <tchughesiv@gmail.com>